### PR TITLE
Pubtator central patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/greenelab/pubtator.svg?branch=master)](https://travis-ci.org/greenelab/pubtator)
 
-[PubTator](https://www.ncbi.nlm.nih.gov/CBBresearch/Lu/Demo/PubTator/) uses text mining to tag PubMed abstracts with standardized concepts. This repository retrieves and processes PubTator annotations for use in [`greenelab/snorkeling`](https://github.com/greenelab/snorkeling) and elsewhere.
+[PubTator](https://www.ncbi.nlm.nih.gov/CBBresearch/Lu/Demo/PubTator/) and its 2.0 version ([PubTator Central](https://www.ncbi.nlm.nih.gov/CBBresearch/Lu/Demo/PubTatorCentral/)) uses text mining to tag PubMed abstracts/artciles with standardized concepts. This repository retrieves and processes PubTator annotations for use in [`greenelab/snorkeling`](https://github.com/greenelab/snorkeling) and elsewhere.
 
 ## Environment
 
@@ -12,7 +12,17 @@ Install the [conda](https://conda.io) environment specified in [`environment.yml
 conda env create --file environment.yml
 ```
 
-Activate with `source activate pubtator`.
+Activate with `conda activate pubtator`.
+
+## Execution
+
+To download and extract Pubator Central's data (default) run the following:
+
+```sh
+bash execute.sh
+```
+
+If the original Pubtator is desired run the above command with the following flag: --pubtator.
 
 ## License
 

--- a/data/example/2-sample-docs.xml
+++ b/data/example/2-sample-docs.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?><!DOCTYPE collection SYSTEM 'BioC.dtd'>
 <collection>
   <source>Pubtator</source>
-  <date>2017/07/13</date>
+  <date>2020/01/10</date>
   <key>Pubtator.key</key>
 <document>
   <id>1</id>

--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,9 @@
 name: pubtator
 dependencies:
-- python==3.6.0
-- lxml==4.4.2
-- tqdm==4.41.1
-- pandas==0.25.3
-- pip==19.3.1
+- python=3.8
+- lxml=4.4
+- tqdm=4.41
+- pandas=0.25.3
+- pip
 - pip:
     - git+https://github.com/en-dash/PyBioC@a21bd181ce3b89de791db4bb7db6ca1c48167648

--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,9 @@
-name: pubtator
+name: pubtator-test
 dependencies:
-- python=3.6.0
-- lxml=3.7.2
-- tqdm=4.11.2
-- pandas=0.20.2
+- python==3.6.0
+- lxml==4.4.2
+- tqdm==4.41.1
+- pandas==0.25.3
+- pip==19.3.1
 - pip:
     - git+https://github.com/en-dash/PyBioC@a21bd181ce3b89de791db4bb7db6ca1c48167648

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: pubtator-test
+name: pubtator
 dependencies:
 - python==3.6.0
 - lxml==4.4.2

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: pubtator
 dependencies:
 - python=3.8
 - lxml=4.4
-- tqdm=4.41
+- tqdm
 - pandas=0.25.3
 - pip
 - pip:

--- a/execute.sh
+++ b/execute.sh
@@ -1,25 +1,55 @@
 # Exit on an error
 set -o errexit
 
-# PubTator FTP download
-FTP_URL=ftp://ftp.ncbi.nlm.nih.gov/pub/lu/PubTator
-wget \
-  --timestamping \
-  --directory-prefix=download \
-  --output-file=download/bioconcepts2pubtator_offsets.gz.log \
-  $FTP_URL/bioconcepts2pubtator_offsets.gz
+if [ "$1" == "--pubtator" ]; then
+  # PubTator FTP download
+  FTP_URL=ftp://ftp.ncbi.nlm.nih.gov/pub/lu/PubTator;
 
-# Convert pubtator format to BioC XML
-python scripts/pubtator_to_xml.py \
-  --documents download/bioconcepts2pubtator_offsets.gz \
-  --output data/pubtator-docs.xml.xz
+  wget \
+    --timestamping \
+    --directory-prefix=download \
+    --output-file=download/bioconcepts2pubtator_offsets.gz.log \
+    $FTP_URL/bioconcepts2pubtator_offsets.gz
 
-# Extract tags from the BioC XML to a TSV
-python scripts/extract_tags.py \
-  --input data/pubtator-docs.xml.xz \
-  --output data/pubtator-tags.tsv.xz
+  # Convert pubtator format to BioC XML
+  python scripts/pubtator_to_xml.py \
+    --documents download/bioconcepts2pubtator_offsets.gz \
+    --output data/pubtator-docs.xml.xz
 
-# Extract hetnet tags from the pubtator tags
-python scripts/hetnet_id_extractor.py \
-  --input data/pubtator-tags.tsv.xz \
-  --output data/pubtator-hetnet-tags.tsv.xz
+  # Extract tags from the BioC XML to a TSV
+  python scripts/extract_tags.py \
+    --input data/pubtator-docs.xml.xz \
+    --output data/pubtator-tags.tsv.xz
+
+  # Extract hetnet tags from the pubtator tags
+  python scripts/hetnet_id_extractor.py \
+    --input data/pubtator-tags.tsv.xz \
+    --output data/pubtator-hetnet-tags.tsv.xz
+
+else
+  # PubTator Central FTP download
+  FTP_URL=ftp://ftp.ncbi.nlm.nih.gov/pub/lu/PubTatorCentral;
+
+  wget \
+    --timestamping \
+    --directory-prefix=download \
+    --output-file=download/bioconcepts2pubtatorcentral_offset.gz.log \
+    $FTP_URL/bioconcepts2pubtatorcentral.offset.gz
+
+  # Convert pubtator format to BioC XML
+  python scripts/pubtator_to_xml.py \
+    --documents download/bioconcepts2pubtatorcentral.offset.gz \
+    --output data/pubtator-central-docs.xml.xz
+
+  # Extract tags from the BioC XML to a TSV
+  python scripts/extract_tags.py \
+    --input data/pubtator-central-docs.xml.xz \
+    --output data/pubtator-central-tags.tsv.xz
+
+  # Extract hetnet tags from the pubtator tags
+  python scripts/hetnet_id_extractor.py \
+    --input data/pubtator-central-tags.tsv.xz \
+    --output data/pubtator-central-hetnet-tags.tsv.xz
+
+fi
+

--- a/scripts/hetnet_id_extractor.py
+++ b/scripts/hetnet_id_extractor.py
@@ -5,6 +5,88 @@ import tqdm
 
 import utilities
 
+def filter_tags(infile, outfile):
+    """ This method filters pubtator tags to consist of only 
+        hetnet tags
+
+        Keyword arguments:
+        infile -- the name of the file to read
+        outfile -- the name of the output file
+    """
+
+    print_header = True
+    hetnet_chemical_df = load_chemical_df()
+    hetnet_disease_df = load_disease_df()
+    hetnet_gene_df = load_gene_df()
+    csv_opener = utilities.get_opener(outfile)
+
+    with csv_opener(outfile, "wt") as tsv_file:
+        for extracted_tag_df in tqdm.tqdm(get_tag_chunks(infile)):
+
+            # Covert chemical IDs
+            chemical_merged_df = (
+                pd.merge(
+                    extracted_tag_df[extracted_tag_df["type"] == "Chemical"], 
+                    hetnet_chemical_df[["drugbank_id", "identifier"]], 
+                    left_on="identifier", 
+                    right_on="identifier"
+                )
+                .drop_duplicates()
+                .replace({"type": {"Chemical": "Compound"}})
+                [["pubmed_id", "type", "offset", "end", "drugbank_id"]]
+                .rename(columns={"drugbank_id": "identifier"})
+            )
+
+            # Convert Disease IDs
+            disease_merged_df = (
+                pd.merge(
+                    extracted_tag_df[extracted_tag_df["type"] == "Disease"], 
+                    hetnet_disease_df[["doid_code", "resource_id"]], 
+                    left_on="identifier", 
+                    right_on="resource_id"
+                )
+                .drop_duplicates()
+                [["pubmed_id", "type", "offset", "end", "doid_code"]]
+                .rename(columns={"doid_code": "identifier"})
+            )
+
+            # Verify Gene IDs are human genes
+            gene_df = extracted_tag_df[extracted_tag_df["type"] == "Gene"]
+            gene_final_df = gene_df[gene_df["identifier"].isin(hetnet_gene_df["GeneID"])]
+
+            final_df = (
+                gene_final_df
+                .append(chemical_merged_df)
+                .append(disease_merged_df)
+            )
+
+            if print_header:
+                (
+                    final_df
+                    [["pubmed_id", "type", "identifier", "offset", "end"]]
+                    .sort_values(["pubmed_id", "offset"])
+                    .to_csv(tsv_file, sep="\t", index=False)
+                )
+
+                print_header = False
+            else:
+                (
+                    final_df
+                    [["pubmed_id", "type", "identifier", "offset", "end"]]
+                    .sort_values(["pubmed_id", "offset"])
+                    .to_csv(tsv_file, sep="\t", index=False, header=False)
+                )
+
+
+def get_tag_chunks(filename):
+    """ Chunk the pandas dataframe so not everything is read into memory
+
+        Keyword Arguments:
+        filename -- the file to read through pandas
+    """
+    chunksize = 10 ** 6
+    for chunk in pd.read_table(filename, chunksize=chunksize):
+        yield chunk
 
 def filter_tags(infile, outfile):
     """ This method filters pubtator tags to consist of only 

--- a/scripts/pubtator_to_xml.py
+++ b/scripts/pubtator_to_xml.py
@@ -92,16 +92,33 @@ def pubtator_stanza_to_article(lines):
     article["pubmed_id"] = title_heading[0]
     article["title"] = title_heading[2]
     title_len = len(title_heading[2])
+
     # abstract
     abstract_heading = lines[1].split("|")
     article["abstract"] = abstract_heading[2]
 
+    # Fix null characters
+    fixed_lines = [
+        str_with_null.replace('\x00', '')
+        for str_with_null in lines[2:]
+    ]
+
     # set up the csv reader
-    annts = csv.DictReader(lines[2:], fieldnames=['pubmed_id', 'start', 'end', 'term', 'type', 'tag_id'], delimiter="\t", quoting=csv.QUOTE_NONE)
+    annts = (
+        csv.DictReader(
+            fixed_lines, 
+            fieldnames=['pubmed_id', 'start', 'end', 'term', 'type', 'tag_id'], 
+            delimiter="\t", 
+            quoting=csv.QUOTE_NONE
+        )
+    )
+
     annts = list(annts)
+    
     for annt in annts:
         for key in 'start', 'end':
             annt[key] = int(annt[key])
+
     annts.sort(key=lambda x: x["start"])
     article["title_annot"] = filter(lambda x: x["start"] < title_len, annts)
     article["abstract_annot"] = filter(lambda x: x["start"] > title_len, annts)


### PR DESCRIPTION
Closes #4  #18 
This patch updates the pubtator repository to download and extract [Pubtator Central](https://www.ncbi.nlm.nih.gov/research/pubtator/). Pubtator Central is Pubtator's 2.0 version and contains different url links. 